### PR TITLE
bump: ci remote docker 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
       - attach_workspace:
           at: ~/workdir
       - setup_remote_docker:
-          version: 20.10.14
+          version: docker24
       - run:
           name: << parameters.cmd_name >>
           command: << parameters.cmd >>


### PR DESCRIPTION
Bump to latest version since current will be deprecated this year.
[REL-1497](https://codacy.atlassian.net/browse/REL-1497)

[REL-1497]: https://codacy.atlassian.net/browse/REL-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ