### PR TITLE
feature: Fallback search for line number; Smallest version update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target
 bin
 cache
 *.gen.go
+.codacyrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,20 @@ WORKDIR /src
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 RUN go mod verify
 
 COPY cmd cmd
 COPY internal internal
 
-RUN go build -o bin/codacy-trivy -ldflags="-s -w" ./cmd/tool
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
+    go build -o bin/codacy-trivy -ldflags="-s -w" ./cmd/tool
 
 COPY docs docs
 
-RUN go run ./cmd/docgen
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
+    go run ./cmd/docgen
 
 FROM busybox
 

--- a/docs/multiple-tests/all-patterns/results.xml
+++ b/docs/multiple-tests/all-patterns/results.xml
@@ -8,7 +8,7 @@
     </file>
     <file name="gradle/gradle.lockfile">
         <error source="vulnerability" line="1"
-            message="Insecure dependency org.apache.logging.log4j:log4j-core:2.17.0 (CVE-2021-44832: log4j-core: remote code execution via JDBC Appender) (update to 2.3.2, 2.12.4, 2.17.1)"
+            message="Insecure dependency org.apache.logging.log4j:log4j-core:2.17.0 (CVE-2021-44832: log4j-core: remote code execution via JDBC Appender) (update to 2.17.1)"
             severity="error" />
     </file>
 </checkstyle>

--- a/docs/multiple-tests/pattern-vulnerability/results.xml
+++ b/docs/multiple-tests/pattern-vulnerability/results.xml
@@ -1,48 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <checkstyle version="1.5">
-    <!--
     <file name="dart/pubspec.lock">
         <error source="vulnerability" line="20"
-            message="Insecure dependency dio@4.0.0 (CVE-2021-31402: dio vulnerable to CRLF injection with HTTP
-    method string) (update to 5.0.0)"
+            message="Insecure dependency dio@4.0.0 (CVE-2021-31402: dio vulnerable to CRLF injection with HTTP method string) (update to 5.0.0)"
             severity="error" />
     </file>
 
     <file
-    name="golang/go.mod">
-        <error source="vulnerability" line="5" message="Insecure dependency golang.org/x/net@v0.16.0
-    (CVE-2023-45288: golang: net/http, x/net/http2: unlimited number of CONTINUATION frames causes
-    DoS) (update to 0.23.0)" severity="error" />
-        <error source="vulnerability" line="5" message="Insecure dependency golang.org/x/net@v0.16.0
-    (CVE-2023-39325: golang: net/http, x/net/http2: rapid stream resets can cause excessive work
-    (CVE-2023-44487)) (update to 0.17.0)" severity="error" />
-        <error source="vulnerability" line="5" message="Insecure dependency golang.org/x/net@v0.16.0
-    (CVE-2023-44487: HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack
-    (Rapid Reset Attack)) (update to 0.17.0)" severity="error" />
-    </file>
--->
-
-    <file name="dart/pubspec.lock">
-        <!-- TODO: If this tests fail, dart can now be supported. Update the Language file and
-        docs. -->
-        <error message="Line numbers not supported"></error>
-    </file>
-
-    <file name="golang/go.mod">
-        <!-- TODO: If this tests fail, golang can now be supported. Update the Language file and
-        docs. -->
-        <error message="Line numbers not supported"></error>
+        name="golang/go.mod">
+        <error source="vulnerability" line="5"
+            message="Insecure dependency golang.org/x/net@v0.16.0 (CVE-2023-45288: golang: net/http, x/net/http2: unlimited number of CONTINUATION frames causes DoS) (update to 0.23.0)"
+            severity="error" />
+        <error source="vulnerability" line="5"
+            message="Insecure dependency golang.org/x/net@v0.16.0 (CVE-2023-39325: golang: net/http, x/net/http2: rapid stream resets can cause excessive work (CVE-2023-44487)) (update to 0.17.0)"
+            severity="error" />
+        <error source="vulnerability" line="5"
+            message="Insecure dependency golang.org/x/net@v0.16.0 (CVE-2023-44487: HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack (Rapid Reset Attack)) (update to 0.17.0)"
+            severity="error" />
     </file>
 
     <file name="gradle/gradle.lockfile">
         <error source="vulnerability" line="1"
-            message="Insecure dependency org.apache.logging.log4j:log4j-core:2.17.0 (CVE-2021-44832: log4j-core: remote code execution via JDBC Appender) (update to 2.3.2, 2.12.4, 2.17.1)"
+            message="Insecure dependency org.apache.logging.log4j:log4j-core:2.17.0 (CVE-2021-44832: log4j-core: remote code execution via JDBC Appender) (update to 2.17.1)"
             severity="error" />
     </file>
 
     <file name="java/pom.xml">
-        <error source="vulnerability" line="13"
-            message="Insecure dependency org.apache.logging.log4j:log4j-core:2.17.0 (CVE-2021-44832: log4j-core: remote code execution via JDBC Appender) (update to 2.3.2, 2.12.4, 2.17.1)"
+        <error source="vulnerability" line="14"
+            message="Insecure dependency org.apache.logging.log4j:log4j-core:2.17.0 (CVE-2021-44832: log4j-core: remote code execution via JDBC Appender) (update to 2.17.1)"
             severity="error" />
     </file>
 
@@ -54,7 +39,7 @@
             message="Insecure dependency axios@0.21.0 (CVE-2021-3749: nodejs-axios: Regular expression denial of service in trim function) (update to 0.21.2)"
             severity="error" />
         <error source="vulnerability" line="14"
-            message="Insecure dependency axios@0.21.0 (CVE-2023-45857: axios: exposure of confidential data stored in cookies) (update to 1.6.0, 0.28.0)"
+            message="Insecure dependency axios@0.21.0 (CVE-2023-45857: axios: exposure of confidential data stored in cookies) (update to 0.28.0)"
             severity="error" />
     </file>
 
@@ -66,7 +51,7 @@
             message="Insecure dependency axios@0.21.0 (CVE-2021-3749: nodejs-axios: Regular expression denial of service in trim function) (update to 0.21.2)"
             severity="error" />
         <error source="vulnerability" line="5"
-            message="Insecure dependency axios@0.21.0 (CVE-2023-45857: axios: exposure of confidential data stored in cookies) (update to 1.6.0, 0.28.0)"
+            message="Insecure dependency axios@0.21.0 (CVE-2023-45857: axios: exposure of confidential data stored in cookies) (update to 0.28.0)"
             severity="error" />
     </file>
 
@@ -101,7 +86,6 @@
             message="Insecure dependency puma@6.3.0 (CVE-2024-21647: rubygem-puma: HTTP request smuggling when parsing chunked Transfer-Encoding Bodies) (update to ~> 5.6.8, >= 6.4.2)"
             severity="error" />
     </file>
-
 
     <file name="swift/Package.resolved">
         <error source="vulnerability" line="67"

--- a/docs/multiple-tests/pattern-vulnerability/src/java/pom.xml
+++ b/docs/multiple-tests/pattern-vulnerability/src/java/pom.xml
@@ -1,5 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.example</groupId>


### PR DESCRIPTION
* For package managers (and other situations) when the line number isn't available, it tries to infer it from the dependencies file contents on a best-effort basis. Provides tentative support for Go/go.mod, Dart/pubspec.lock, although it's probably best to leave those publically undocumented.
* Suggests a single version update, always newer and with the least upgrade path to the currently installed version.