### PR TITLE
fix: Change vulnerable dependency for Python library tests

### DIFF
--- a/docs/multiple-tests/pattern-vulnerability-medium/results.xml
+++ b/docs/multiple-tests/pattern-vulnerability-medium/results.xml
@@ -35,7 +35,7 @@
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency stdlib@v1.21.4 (CVE-2023-45290: golang: net/http: memory exhaustion in Request.ParseMultipartForm) (update to 1.21.8)"
+            message="Insecure dependency stdlib@v1.21.4 (CVE-2023-45290: golang: net/http: golang: mime/multipart: golang: net/textproto: memory exhaustion in Request.ParseMultipartForm) (update to 1.21.8)"
             severity="warning"
         />
         <error

--- a/docs/multiple-tests/pattern-vulnerability/results.xml
+++ b/docs/multiple-tests/pattern-vulnerability/results.xml
@@ -92,7 +92,7 @@
         <error
             source="vulnerability"
             line="2"
-            message="Insecure dependency openstack-heat@v22.0.1 (CVE-2024-7319: openstack-heat: Incomplete fix for CVE-2023-1625) (no fix available)"
+            message="Insecure dependency openstack-heat@v19.0.0 (CVE-2023-1625: openstack-heat: information leak in API) (update to 20.0.0)"
             severity="error"
         />
     </file>

--- a/docs/multiple-tests/pattern-vulnerability/src/python/requirements.txt
+++ b/docs/multiple-tests/pattern-vulnerability/src/python/requirements.txt
@@ -1,2 +1,2 @@
 # dependencies
-openstack-heat==v22.0.1
+openstack-heat==v19.0.0


### PR DESCRIPTION
This change guarantees that a critical vulnerability result is still produced.