### PR TITLE
fix: Don't require plugin tests when updating vulnerabilities DB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,11 +87,6 @@ workflows:
           name: publish_docker_local
           requires:
             - install_trivy_and_download_dbs
-      - codacy_plugins_test/run:
-          name: plugins_test
-          run_multiple_tests: true
-          requires:
-            - publish_docker_local
       - codacy/publish_docker:
           name: publish_dockerhub
           context: CodacyDocker
@@ -102,7 +97,7 @@ workflows:
             docker tag "$CIRCLE_PROJECT_REPONAME:latest" "codacy/$CIRCLE_PROJECT_REPONAME:latest"
             docker push --all-tags "codacy/$CIRCLE_PROJECT_REPONAME"
           requires:
-            - plugins_test
+            - publish_docker_local
       - codacy/mirror_to_ecr:
           context: CodacyAWS
           name: mirror_to_ecr_integration


### PR DESCRIPTION
Plugin tests failures, due to more expected vulnerabilities coming from DB updates, will surface when developing, in the `compile_test_deploy` workflow.