### PR TITLE
Make Trivy DB update earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,8 @@ workflows:
   update_vulnerability_dbs:
     triggers:
       - schedule:
-          # this is running at 2am everyday to avoid doing it at midnight (same time as nightly)
-          cron: "0 2 * * *"
+          # run at 00:30 UTC (30 minutes after being updated on the source)
+          cron: "30 0 * * *"
           filters:
             branches:
               only:

--- a/docs/multiple-tests/pattern-vulnerability-medium/results.xml
+++ b/docs/multiple-tests/pattern-vulnerability-medium/results.xml
@@ -110,6 +110,18 @@
             message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-22871: net/http: Request smuggling due to acceptance of invalid chunked data in net/http) (update to 1.23.8)"
             severity="warning"
         />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-0913: Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in syscall) (update to 1.23.10)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-4673: net/http: Sensitive headers not cleared on cross-origin redirect in net/http) (update to 1.23.10)"
+            severity="warning"
+        />
     </file>
 
     <file name="gradle/gradle.lockfile">
@@ -173,6 +185,24 @@
             message="Insecure dependency pypi/requests@2.30.0 (CVE-2024-35195: requests: subsequent requests to the same host ignore cert verification) (update to 2.32.0)"
             severity="warning"
         />
+        <error
+            source="vulnerability_medium"
+            line="131"
+            message="Insecure dependency pypi/requests@2.30.0 (CVE-2024-47081: requests: Requests vulnerable to .netrc credentials leak via malicious URLs) (update to 2.32.4)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="140"
+            message="Insecure dependency pypi/urllib3@2.2.2 (CVE-2025-50181: urllib3: urllib3 redirects are not disabled when retries are disabled on PoolManager instantiation) (update to 2.5.0)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="140"
+            message="Insecure dependency pypi/urllib3@2.2.2 (CVE-2025-50182: urllib3: urllib3 does not control redirects in browsers and Node.js) (update to 2.5.0)"
+            severity="warning"
+        />
     </file>
 
     <file name="python/requirements.txt">
@@ -186,6 +216,12 @@
             source="vulnerability_medium"
             line="2"
             message="Insecure dependency pypi/requests@v2.30.0 (CVE-2024-35195: requests: subsequent requests to the same host ignore cert verification) (update to 2.32.0)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="2"
+            message="Insecure dependency pypi/requests@v2.30.0 (CVE-2024-47081: requests: Requests vulnerable to .netrc credentials leak via malicious URLs) (update to 2.32.4)"
             severity="warning"
         />
     </file>

--- a/docs/multiple-tests/pattern-vulnerability/results.xml
+++ b/docs/multiple-tests/pattern-vulnerability/results.xml
@@ -52,6 +52,18 @@
             message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-0312: ollama: NULL Pointer Dereference in ollama/ollama) (no fix available)"
             severity="error"
         />
+        <error
+            source="vulnerability"
+            line="8"
+            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2024-8063: ollama: Divide by Zero in ollama/ollama) (no fix available)"
+            severity="error"
+        />
+        <error
+            source="vulnerability"
+            line="8"
+            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-1975: ollama: Improper Validation of Array Index in ollama/ollama) (no fix available)"
+            severity="error"
+        />
         <!-- stdlib -->
         <error
             source="vulnerability"


### PR DESCRIPTION
With more orgs being added to proactive SCA and a trend on regular analysis starting earlier in the day there is starting to be quite a bit of overlap between SCA jobs and regular jobs resulting in worst analysis times.

Trivy-db is built and published to GH Container Registry every 6 hours (https://github.com/aquasecurity/trivy-db/blob/main/.github/workflows/cron.yml#L5) resulting in a publishing schedule of 6:00 UTC, 12:00 UTC, 18:00 UTC and 00:00 UTC (https://github.com/aquasecurity/trivy-db/pkgs/container/trivy-db).

With this scheduled we should be ok to run the Trivy DB update cron at 00:30 UTC with good guarantees of having fresh data.