### PR TITLE
feature: Return underlying ruleId as sourceId CF-1812

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2
 	github.com/aquasecurity/trivy v0.59.1 // Also update .config.yml
 	github.com/aquasecurity/trivy-db v0.0.0-20241209111357-8c398f13db0e
-	github.com/codacy/codacy-engine-golang-seed/v6 v6.3.0
+	github.com/codacy/codacy-engine-golang-seed/v6 v6.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/samber/lo v1.51.0

--- a/go.sum
+++ b/go.sum
@@ -934,8 +934,8 @@ github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3 h1:boJj011Hh+874zpIySe
 github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cockroachdb/apd/v3 v3.2.1 h1:U+8j7t0axsIgvQUqthuNm82HIrYXodOV2iWLWtEaIwg=
 github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
-github.com/codacy/codacy-engine-golang-seed/v6 v6.3.0 h1:kGwieci9KOXZcmfKLnUHND3aY9RiEJoS8/zMokVwnvw=
-github.com/codacy/codacy-engine-golang-seed/v6 v6.3.0/go.mod h1:Ir7lvmQQeEd7xF7Z+XNaY+UGq6CBXil2rEmKhNDkVRk=
+github.com/codacy/codacy-engine-golang-seed/v6 v6.4.0 h1:IEBZi96MMt7hXCovJFTI8GU7hFz5wnzVwVZZv9j69Ec=
+github.com/codacy/codacy-engine-golang-seed/v6 v6.4.0/go.mod h1:Ir7lvmQQeEd7xF7Z+XNaY+UGq6CBXil2rEmKhNDkVRk=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -209,6 +209,7 @@ func (t codacyTrivy) getVulnerabilities(ctx context.Context, report ptypes.Repor
 					Line:      lineNumberByPurl[purl],
 					Message:   fmt.Sprintf("Insecure dependency %s (%s: %s) %s", purlPrettyPrint(*vuln.PkgIdentifier.PURL), vuln.VulnerabilityID, vuln.Title, fixedVersionMessage),
 					PatternID: ruleID,
+					SourceID:  vuln.VulnerabilityID,
 				},
 			)
 		}
@@ -270,6 +271,7 @@ func (t codacyTrivy) runSecretScanning(toolExecution codacy.ToolExecution) []cod
 					Message:   fmt.Sprintf("Possible hardcoded secret: %s", result.Title),
 					PatternID: ruleIDSecret,
 					Line:      result.StartLine,
+					SourceID:  result.RuleID,
 				},
 			)
 		}

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -224,18 +224,21 @@ func TestRun(t *testing.T) {
 				Line:      1,
 				PatternID: ruleIDVulnerability,
 				Message:   "Insecure dependency type/@namespace/package-1@version+incompatible (vuln id: vuln title) (update to vuln fixed)",
+				SourceID:  "vuln id",
 			},
 			{
 				File:      fileName,
 				Line:      1,
 				PatternID: ruleIDVulnerability,
 				Message:   "Insecure dependency type/@namespace/package-1@version+incompatible (vuln id no fixed version: vuln no fixed version) (no fix available)",
+				SourceID:  "vuln id no fixed version",
 			},
 			{
 				File:      fileName,
 				Line:      1,
 				PatternID: ruleIDSecret,
 				Message:   "Possible hardcoded secret: AWS Access Key ID",
+				SourceID:  "aws-access-key-id",
 			},
 		}
 		issues := lo.Filter(results, func(result codacy.Result, _ int) bool {


### PR DESCRIPTION
The sourceId will contain the ruleId returned by Trivy, Trivy standardizes to ruleId when returning SARIF for example, but it can also be called VulnerabilityID, they have the same value

Trivy examples:
  "ruleId": "CVE-2025-22870"
  "ruleId": "CVE-2025-22872"
  "ruleId": "aws-access-key-id"

Example building and running locally:

Vulnerabilities: (scroll to the right to see the sourceId at the end)
```
{"patternId":"vulnerability_medium","filename":"gradle/gradle.lockfile","line":4,"message":"Insecure dependency maven/org.apache.cxf/cxf-rt-transports-http@4.0.0 (CVE-2024-41172: apache: cxf: org.apache.cxf:cxf-rt-transports-http: unrestricted memory consumption in CXF HTTP clients) (update to 4.0.5)","sourceId":"CVE-2024-41172"}
{"patternId":"vulnerability_medium","filename":"gradle/gradle.lockfile","line":1,"message":"Insecure dependency maven/org.apache.logging.log4j/log4j-core@2.17.0 (CVE-2021-44832: log4j-core: remote code execution via JDBC Appender) (update to 2.17.1)","sourceId":"CVE-2021-44832"}
```

Secrets: (scroll to the right to see the sourceId at the end)
```
{"patternId":"secret","filename":"aws-config.txt","line":2,"message":"Possible hardcoded secret: AWS Access Key ID","sourceId":"aws-access-key-id"}
{"patternId":"secret","filename":"aws-config.txt","line":1,"message":"Possible hardcoded secret: AWS Secret Access Key","sourceId":"aws-secret-access-key"}
```

With the examples, we can see different sourceId that will allow us to generated different UUID


PS: I tested manually, as when checked what it would take to change the codacy-plugins-test, I created a task instead, that has some chained dependencies 🥲 https://codacy.atlassian.net/browse/CF-1827