### PR TITLE
feat: populate ExtraFields with dependency chains, CVE, fixVersion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.10.0
 	github.com/aquasecurity/trivy v0.70.0 // Also update .circle/config.yml
 	github.com/aquasecurity/trivy-db v0.0.0-20251222105351-a833f47f8f0d
-	github.com/codacy/codacy-engine-golang-seed/v8 v8.0.2
+	github.com/codacy/codacy-engine-golang-seed/v8 v8.0.4
 	github.com/google/go-cmp v0.7.0
 	github.com/package-url/packageurl-go v0.1.6
 	github.com/samber/lo v1.53.0

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/T
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/codacy/codacy-engine-golang-seed/v8 v8.0.2 h1:zWl/pb6vbShqSWRjaisFdX2HJF4HosL//9JsDMnCCNM=
 github.com/codacy/codacy-engine-golang-seed/v8 v8.0.2/go.mod h1:5ILW/DZUg28afocIekbbnLEKEkBNyFx0ayrIKS/3TKg=
+github.com/codacy/codacy-engine-golang-seed/v8 v8.0.4 h1:L0SDrJX5/N7eXnxwOWUXl4xcorSxX5Q9ercowiaW9fI=
+github.com/codacy/codacy-engine-golang-seed/v8 v8.0.4/go.mod h1:5ILW/DZUg28afocIekbbnLEKEkBNyFx0ayrIKS/3TKg=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6dyLYXQ=

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -569,11 +569,16 @@ func buildDependencyChains(targetPURL string, packages []ftypes.Package) [][]str
 			out = append(out, trimChainTail(path, maxDependencyChainLen))
 			return
 		}
+		before := len(out)
 		for _, parentUID := range parents {
 			if len(out) >= maxDependencyChains {
 				return
 			}
 			dfs(parentUID, path, visited)
+		}
+		// All parent branches were blocked by cycle detection — treat current node as root.
+		if len(out) == before {
+			out = append(out, trimChainTail(path, maxDependencyChainLen))
 		}
 	}
 

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -183,20 +183,17 @@ func (t codacyTrivy) getVulnerabilities(ctx context.Context, report ptypes.Repor
 
 	issues := []codacy.Issue{}
 	for _, result := range report.Results {
-		// Make maps for faster lookup
+		// Make a map for faster lookup
 		lineNumberByPurl := map[string]int{}
-		pkgByPurl := map[string]ftypes.Package{}
 		for _, pkg := range result.Packages {
 			if pkg.Identifier.PURL == nil {
 				continue
 			}
-			purl := pkg.Identifier.PURL.ToString()
 			lineNumber := 0
 			if len(pkg.Locations) > 0 {
 				lineNumber = pkg.Locations[0].StartLine
 			}
-			lineNumberByPurl[purl] = lineNumber
-			pkgByPurl[purl] = pkg
+			lineNumberByPurl[pkg.Identifier.PURL.ToString()] = lineNumber
 		}
 
 		// Ensure Trivy only produces results with severities matching the specified patterns.
@@ -236,7 +233,7 @@ func (t codacyTrivy) getVulnerabilities(ctx context.Context, report ptypes.Repor
 				return nil, err
 			}
 
-			chains := buildDependencyChains(purl, pkgByPurl)
+			chains := buildDependencyChains(purl, result.Packages)
 			extraFields, err := json.Marshal(map[string]any{
 				"dependenciesChains": chains,
 				"CVE":                vuln.VulnerabilityID,
@@ -518,43 +515,69 @@ func unencodeComponents(bom *cdx.BOM) {
 	}
 }
 
-// buildDependencyChains enumerates parent chains for a vulnerable PURL via DFS.
-// Each chain is ordered root-most first, vulnerable PURL last.
+// buildDependencyChains enumerates root-to-vulnerable chains for a vulnerable PURL via DFS.
+// Each chain is ordered root-most first, vulnerable package last.
+// DependsOn in Trivy lists a package's children (what it depends on). To find parents
+// (what depends on the vulnerable package), we build an inverted map keyed by UID.
 // Limits: max maxDependencyChains chains; per-chain length capped at maxDependencyChainLen (tail kept).
-func buildDependencyChains(target string, pkgByPurl map[string]ftypes.Package) [][]string {
-	var out [][]string
+func buildDependencyChains(targetPURL string, packages []ftypes.Package) [][]string {
+	// Map from UID to package for name resolution.
+	pkgByUID := make(map[string]ftypes.Package, len(packages))
+	// Inverted map: child UID -> parent UIDs (packages that depend on this child).
+	parentsByUID := make(map[string][]string)
+	targetUID := ""
 
-	var dfs func(current string, path []string, visited map[string]bool)
-	dfs = func(current string, path []string, visited map[string]bool) {
-		if len(out) >= maxDependencyChains {
-			return
+	for _, pkg := range packages {
+		uid := pkg.Identifier.UID
+		pkgByUID[uid] = pkg
+		if pkg.Identifier.PURL != nil && pkg.Identifier.PURL.ToString() == targetPURL {
+			targetUID = uid
 		}
-		if visited[current] {
-			return
-		}
-		visited[current] = true
-		defer delete(visited, current)
-
-		pkg, ok := pkgByPurl[current]
-		name := purlPrettyPrint(*pkg.Identifier.PURL)
-		if !ok {
-			name = current
-		}
-		path = append([]string{name}, path...)
-
-		if !ok || len(pkg.DependsOn) == 0 {
-			out = append(out, trimChainTail(path, maxDependencyChainLen))
-			return
-		}
-		for _, parent := range pkg.DependsOn {
-			if len(out) >= maxDependencyChains {
-				return
-			}
-			dfs(parent, path, visited)
+		for _, depUID := range pkg.DependsOn {
+			parentsByUID[depUID] = append(parentsByUID[depUID], uid)
 		}
 	}
 
-	dfs(target, nil, map[string]bool{})
+	if targetUID == "" {
+		return nil
+	}
+
+	var out [][]string
+
+	var dfs func(currentUID string, path []string, visited map[string]bool)
+	dfs = func(currentUID string, path []string, visited map[string]bool) {
+		if len(out) >= maxDependencyChains {
+			return
+		}
+		if visited[currentUID] {
+			return
+		}
+		visited[currentUID] = true
+		defer delete(visited, currentUID)
+
+		pkg, ok := pkgByUID[currentUID]
+		var name string
+		if ok && pkg.Identifier.PURL != nil {
+			name = purlPrettyPrint(*pkg.Identifier.PURL)
+		} else {
+			name = currentUID
+		}
+		path = append([]string{name}, path...)
+
+		parents := parentsByUID[currentUID]
+		if len(parents) == 0 {
+			out = append(out, trimChainTail(path, maxDependencyChainLen))
+			return
+		}
+		for _, parentUID := range parents {
+			if len(out) >= maxDependencyChains {
+				return
+			}
+			dfs(parentUID, path, visited)
+		}
+	}
+
+	dfs(targetUID, nil, map[string]bool{})
 	return out
 }
 

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -36,6 +36,9 @@ const (
 	ruleIDVulnerabilityMinor    string = "vulnerability_minor"
 	ruleIDMaliciousPackages     string = "malicious_packages"
 
+	maxDependencyChains   = 10
+	maxDependencyChainLen = 20
+
 	// See https://aquasecurity.github.io/trivy/v0.59/docs/scanner/vulnerability/#severity-selection
 	trivySeverityLow      string = "low"
 	trivySeverityMedium   string = "medium"
@@ -180,17 +183,20 @@ func (t codacyTrivy) getVulnerabilities(ctx context.Context, report ptypes.Repor
 
 	issues := []codacy.Issue{}
 	for _, result := range report.Results {
-		// Make a map for faster lookup
+		// Make maps for faster lookup
 		lineNumberByPurl := map[string]int{}
+		pkgByPurl := map[string]ftypes.Package{}
 		for _, pkg := range result.Packages {
 			if pkg.Identifier.PURL == nil {
 				continue
 			}
+			purl := pkg.Identifier.PURL.ToString()
 			lineNumber := 0
 			if len(pkg.Locations) > 0 {
 				lineNumber = pkg.Locations[0].StartLine
 			}
-			lineNumberByPurl[pkg.Identifier.PURL.ToString()] = lineNumber
+			lineNumberByPurl[purl] = lineNumber
+			pkgByPurl[purl] = pkg
 		}
 
 		// Ensure Trivy only produces results with severities matching the specified patterns.
@@ -230,14 +236,25 @@ func (t codacyTrivy) getVulnerabilities(ctx context.Context, report ptypes.Repor
 				return nil, err
 			}
 
+			chains := buildDependencyChains(purl, pkgByPurl)
+			extraFields, err := json.Marshal(map[string]any{
+				"dependenciesChains": chains,
+				"CVE":                vuln.VulnerabilityID,
+				"fixVersion":         fixedVersion,
+			})
+			if err != nil {
+				extraFields = nil
+			}
+
 			issues = append(
 				issues,
 				codacy.Issue{
-					File:      result.Target,
-					Line:      lineNumberByPurl[purl],
-					Message:   fmt.Sprintf("Insecure dependency %s (%s: %s) %s", purlPrettyPrint(*vuln.PkgIdentifier.PURL), vuln.VulnerabilityID, vuln.Title, fixedVersionMessage),
-					PatternID: ruleID,
-					SourceID:  vuln.VulnerabilityID,
+					File:        result.Target,
+					Line:        lineNumberByPurl[purl],
+					Message:     fmt.Sprintf("Insecure dependency %s (%s: %s) %s", purlPrettyPrint(*vuln.PkgIdentifier.PURL), vuln.VulnerabilityID, vuln.Title, fixedVersionMessage),
+					PatternID:   ruleID,
+					SourceID:    vuln.VulnerabilityID,
+					ExtraFields: extraFields,
 				},
 			)
 		}
@@ -499,6 +516,53 @@ func unencodeComponents(bom *cdx.BOM) {
 			}
 		}
 	}
+}
+
+// buildDependencyChains enumerates parent chains for a vulnerable PURL via DFS.
+// Each chain is ordered root-most first, vulnerable PURL last.
+// Limits: max maxDependencyChains chains; per-chain length capped at maxDependencyChainLen (tail kept).
+func buildDependencyChains(target string, pkgByPurl map[string]ftypes.Package) [][]string {
+	var out [][]string
+
+	var dfs func(current string, path []string, visited map[string]bool)
+	dfs = func(current string, path []string, visited map[string]bool) {
+		if len(out) >= maxDependencyChains {
+			return
+		}
+		if visited[current] {
+			return
+		}
+		visited[current] = true
+		defer delete(visited, current)
+
+		pkg, ok := pkgByPurl[current]
+		name := purlPrettyPrint(*pkg.Identifier.PURL)
+		if !ok {
+			name = current
+		}
+		path = append([]string{name}, path...)
+
+		if !ok || len(pkg.DependsOn) == 0 {
+			out = append(out, trimChainTail(path, maxDependencyChainLen))
+			return
+		}
+		for _, parent := range pkg.DependsOn {
+			if len(out) >= maxDependencyChains {
+				return
+			}
+			dfs(parent, path, visited)
+		}
+	}
+
+	dfs(target, nil, map[string]bool{})
+	return out
+}
+
+func trimChainTail(chain []string, max int) []string {
+	if len(chain) <= max {
+		return chain
+	}
+	return chain[len(chain)-max:]
 }
 
 // Remove the pkg: prefix and url-decode the PURL for display purposes.

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -202,6 +202,11 @@ func (t codacyTrivy) getVulnerabilities(ctx context.Context, report ptypes.Repor
 			return nil, &ToolError{msg: "Failed to run Codacy Trivy", w: err}
 		}
 
+		// Precompute the dependency graph once per result (static across vulnerabilities).
+		// Keyed by Package.ID — that is what Trivy's DependsOn references
+		// (pkg/dependency/id.go: "The package ID is used to construct the dependency graph").
+		pkgByID, parentsByID := buildPackageGraph(result.Packages)
+
 		for _, vuln := range result.Vulnerabilities {
 			// Skip vulnerabilities without a valid PURL to avoid panic
 			// This can happen when Trivy detects vulnerabilities in packages that don't have
@@ -233,7 +238,7 @@ func (t codacyTrivy) getVulnerabilities(ctx context.Context, report ptypes.Repor
 				return nil, err
 			}
 
-			chains := buildDependencyChains(purl, result.Packages)
+			chains := buildDependencyChains(vuln.PkgID, pkgByID, parentsByID)
 			extraFields, err := json.Marshal(map[string]any{
 				"dependenciesChains": chains,
 				"CVE":                vuln.VulnerabilityID,
@@ -515,74 +520,83 @@ func unencodeComponents(bom *cdx.BOM) {
 	}
 }
 
-// buildDependencyChains enumerates root-to-vulnerable chains for a vulnerable PURL via DFS.
-// Each chain is ordered root-most first, vulnerable package last.
-// DependsOn in Trivy lists a package's children (what it depends on). To find parents
-// (what depends on the vulnerable package), we build an inverted map keyed by UID.
-// Limits: max maxDependencyChains chains; per-chain length capped at maxDependencyChainLen (tail kept).
-func buildDependencyChains(targetPURL string, packages []ftypes.Package) [][]string {
-	// Map from UID to package for name resolution.
-	pkgByUID := make(map[string]ftypes.Package, len(packages))
-	// Inverted map: child UID -> parent UIDs (packages that depend on this child).
-	parentsByUID := make(map[string][]string)
-	targetUID := ""
-
+// buildPackageGraph precomputes, once per Trivy result, the structures needed to walk the
+// dependency graph: a Package.ID -> Package map for name resolution, and an inverted
+// child-ID -> parent-IDs map.
+//
+// Trivy's pkg.DependsOn lists a package's children keyed by Package.ID — NOT by
+// Identifier.UID (a calculated hash) — see pkg/fanal/analyzer/language/analyze.go
+// (deps[dep.ID] = dep.DependsOn) and pkg/dependency/id.go. Keying by anything other than
+// Package.ID makes every lookup miss, collapsing all chains to single-element ones.
+func buildPackageGraph(packages []ftypes.Package) (map[string]ftypes.Package, map[string][]string) {
+	pkgByID := make(map[string]ftypes.Package, len(packages))
+	parentsByID := make(map[string][]string)
 	for _, pkg := range packages {
-		uid := pkg.Identifier.UID
-		pkgByUID[uid] = pkg
-		if pkg.Identifier.PURL != nil && pkg.Identifier.PURL.ToString() == targetPURL {
-			targetUID = uid
-		}
-		for _, depUID := range pkg.DependsOn {
-			parentsByUID[depUID] = append(parentsByUID[depUID], uid)
+		pkgByID[pkg.ID] = pkg
+		for _, childID := range pkg.DependsOn {
+			parentsByID[childID] = append(parentsByID[childID], pkg.ID)
 		}
 	}
+	return pkgByID, parentsByID
+}
 
-	if targetUID == "" {
+// buildDependencyChains enumerates root-to-vulnerable chains for the package identified by
+// targetID (a Trivy Package.ID, e.g. vuln.PkgID) via DFS over the inverted parent map.
+// Each chain is ordered root-most first, vulnerable package last.
+// Limits: max maxDependencyChains chains; per-chain length capped at maxDependencyChainLen (tail kept).
+func buildDependencyChains(targetID string, pkgByID map[string]ftypes.Package, parentsByID map[string][]string) [][]string {
+	if targetID == "" {
+		return nil
+	}
+	if _, ok := pkgByID[targetID]; !ok {
 		return nil
 	}
 
 	var out [][]string
 
-	var dfs func(currentUID string, path []string, visited map[string]bool)
-	dfs = func(currentUID string, path []string, visited map[string]bool) {
-		if len(out) >= maxDependencyChains {
-			return
-		}
-		if visited[currentUID] {
-			return
-		}
-		visited[currentUID] = true
-		defer delete(visited, currentUID)
-
-		pkg, ok := pkgByUID[currentUID]
-		var name string
-		if ok && pkg.Identifier.PURL != nil {
-			name = purlPrettyPrint(*pkg.Identifier.PURL)
-		} else {
-			name = currentUID
-		}
-		path = append([]string{name}, path...)
-
-		parents := parentsByUID[currentUID]
-		if len(parents) == 0 {
-			out = append(out, trimChainTail(path, maxDependencyChainLen))
-			return
-		}
-		before := len(out)
-		for _, parentUID := range parents {
-			if len(out) >= maxDependencyChains {
-				return
-			}
-			dfs(parentUID, path, visited)
-		}
-		// All parent branches were blocked by cycle detection — treat current node as root.
-		if len(out) == before {
+	// record appends a finished chain, enforcing the maxDependencyChains cap in one place.
+	record := func(path []string) {
+		if len(out) < maxDependencyChains {
 			out = append(out, trimChainTail(path, maxDependencyChainLen))
 		}
 	}
 
-	dfs(targetUID, nil, map[string]bool{})
+	nodeName := func(id string) string {
+		if pkg, ok := pkgByID[id]; ok && pkg.Identifier.PURL != nil {
+			return purlPrettyPrint(*pkg.Identifier.PURL)
+		}
+		return id
+	}
+
+	var dfs func(currentID string, path []string, visited map[string]bool)
+	dfs = func(currentID string, path []string, visited map[string]bool) {
+		if len(out) >= maxDependencyChains || visited[currentID] {
+			return
+		}
+		visited[currentID] = true
+		defer delete(visited, currentID)
+
+		path = append([]string{nodeName(currentID)}, path...)
+
+		parents := parentsByID[currentID]
+		if len(parents) == 0 {
+			record(path)
+			return
+		}
+		before := len(out)
+		for _, parentID := range parents {
+			if len(out) >= maxDependencyChains {
+				return
+			}
+			dfs(parentID, path, visited)
+		}
+		// All parent branches were blocked by cycle detection — treat current node as a root.
+		if len(out) == before {
+			record(path)
+		}
+	}
+
+	dfs(targetID, nil, map[string]bool{})
 	return out
 }
 

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -148,6 +148,7 @@ func TestRun(t *testing.T) {
 				Target: fileName,
 				Packages: ftypes.Packages{
 					{
+						ID: "package-1@version+incompatible",
 						Locations: []ftypes.Location{
 							{
 								StartLine: 1,
@@ -182,6 +183,7 @@ func TestRun(t *testing.T) {
 					// Will generate an issue
 					{
 						VulnerabilityID: "vuln id",
+						PkgID:           "package-1@version+incompatible",
 						Vulnerability: dbtypes.Vulnerability{
 							Severity: "CRITICAL",
 							Title:    "vuln title",
@@ -194,6 +196,7 @@ func TestRun(t *testing.T) {
 					// Will generate an issue
 					{
 						VulnerabilityID: "vuln id no fixed version",
+						PkgID:           "package-1@version+incompatible",
 						Vulnerability: dbtypes.Vulnerability{
 							Severity: "HIGH",
 							Title:    "vuln no fixed version",
@@ -390,9 +393,14 @@ func TestRun(t *testing.T) {
 					Properties: &[]cyclonedx.Property{},
 				},
 				{
-					BOMRef:     "pkg:type/@namespace/package-1@version+incompatible",
-					Type:       "library",
-					Properties: &[]cyclonedx.Property{},
+					BOMRef: "pkg:type/@namespace/package-1@version+incompatible",
+					Type:   "library",
+					Properties: &[]cyclonedx.Property{
+						{
+							Name:  "aquasecurity:trivy:PkgID",
+							Value: "package-1@version+incompatible",
+						},
+					},
 					PackageURL: "pkg:type/@namespace/package-1@version+incompatible",
 					Version:    "version+incompatible",
 				},
@@ -909,10 +917,16 @@ func TestPurlPrettyPrint(t *testing.T) {
 	assert.Equal(t, "type/namespace/name@1.2.0+incompatible", ppp)
 }
 
-func makePkg(uid string, purl *packageurl.PackageURL, dependsOn ...string) ftypes.Package {
+// makePkg builds a Trivy package the way real scans do: the dependency graph (DependsOn,
+// and the targetID passed to buildDependencyChains) is keyed by Package.ID, while
+// Identifier.UID is a separate calculated hash. We deliberately set UID to a value
+// DISTINCT from ID ("uid-"+id) so any code that mistakenly keys the graph by UID instead
+// of ID fails these tests.
+func makePkg(id string, purl *packageurl.PackageURL, dependsOn ...string) ftypes.Package {
 	return ftypes.Package{
+		ID: id,
 		Identifier: ftypes.PkgIdentifier{
-			UID:  uid,
+			UID:  "uid-" + id,
 			PURL: purl,
 		},
 		DependsOn: dependsOn,
@@ -923,11 +937,17 @@ func newPURL(pkgType, namespace, name, version string) *packageurl.PackageURL {
 	return packageurl.NewPackageURL(pkgType, namespace, name, version, nil, "")
 }
 
+// chainsFor precomputes the graph (as production does once per result) then resolves chains.
+func chainsFor(targetID string, packages []ftypes.Package) [][]string {
+	pkgByID, parentsByID := buildPackageGraph(packages)
+	return buildDependencyChains(targetID, pkgByID, parentsByID)
+}
+
 func TestBuildDependencyChains(t *testing.T) {
 	type testData struct {
-		packages    []ftypes.Package
-		targetPURL  string
-		expected    [][]string
+		packages []ftypes.Package
+		targetID string
+		expected [][]string
 	}
 
 	vulnPURL := newPURL("npm", "", "vuln-pkg", "1.0.0")
@@ -936,74 +956,74 @@ func TestBuildDependencyChains(t *testing.T) {
 	sibling1PURL := newPURL("npm", "", "sibling-1", "1.0.0")
 	sibling2PURL := newPURL("npm", "", "sibling-2", "1.0.0")
 
-	vulnUID := vulnPURL.String()
-	parentUID := parentPURL.String()
-	grandparentUID := grandparentPURL.String()
-	sibling1UID := sibling1PURL.String()
-	sibling2UID := sibling2PURL.String()
+	// Package.ID values — what DependsOn and vuln.PkgID reference (name@version).
+	vulnID := "vuln-pkg@1.0.0"
+	parentID := "parent-pkg@2.0.0"
+	grandparentID := "grandparent-pkg@3.0.0"
+	sibling1ID := "sibling-1@1.0.0"
+	sibling2ID := "sibling-2@1.0.0"
 
 	testSet := map[string]testData{
 		"direct dependency — no parents, single-element chain": {
 			packages: []ftypes.Package{
-				makePkg(vulnUID, vulnPURL),
+				makePkg(vulnID, vulnPURL),
 			},
-			targetPURL: vulnUID,
-			expected:   [][]string{{"npm/vuln-pkg@1.0.0"}},
+			targetID: vulnID,
+			expected: [][]string{{"npm/vuln-pkg@1.0.0"}},
 		},
 		"single transitive chain — one parent": {
 			packages: []ftypes.Package{
-				makePkg(vulnUID, vulnPURL),
-				makePkg(parentUID, parentPURL, vulnUID),
+				makePkg(vulnID, vulnPURL),
+				makePkg(parentID, parentPURL, vulnID),
 			},
-			targetPURL: vulnUID,
-			expected:   [][]string{{"npm/parent-pkg@2.0.0", "npm/vuln-pkg@1.0.0"}},
+			targetID: vulnID,
+			expected: [][]string{{"npm/parent-pkg@2.0.0", "npm/vuln-pkg@1.0.0"}},
 		},
 		"deep transitive chain — two ancestors": {
 			packages: []ftypes.Package{
-				makePkg(vulnUID, vulnPURL),
-				makePkg(parentUID, parentPURL, vulnUID),
-				makePkg(grandparentUID, grandparentPURL, parentUID),
+				makePkg(vulnID, vulnPURL),
+				makePkg(parentID, parentPURL, vulnID),
+				makePkg(grandparentID, grandparentPURL, parentID),
 			},
-			targetPURL: vulnUID,
-			expected:   [][]string{{"npm/grandparent-pkg@3.0.0", "npm/parent-pkg@2.0.0", "npm/vuln-pkg@1.0.0"}},
+			targetID: vulnID,
+			expected: [][]string{{"npm/grandparent-pkg@3.0.0", "npm/parent-pkg@2.0.0", "npm/vuln-pkg@1.0.0"}},
 		},
 		"multiple paths to root — two chains": {
 			packages: []ftypes.Package{
-				makePkg(vulnUID, vulnPURL),
-				makePkg(sibling1UID, sibling1PURL, vulnUID),
-				makePkg(sibling2UID, sibling2PURL, vulnUID),
+				makePkg(vulnID, vulnPURL),
+				makePkg(sibling1ID, sibling1PURL, vulnID),
+				makePkg(sibling2ID, sibling2PURL, vulnID),
 			},
-			targetPURL: vulnUID,
+			targetID: vulnID,
 			expected: [][]string{
 				{"npm/sibling-1@1.0.0", "npm/vuln-pkg@1.0.0"},
 				{"npm/sibling-2@1.0.0", "npm/vuln-pkg@1.0.0"},
 			},
 		},
-		"target PURL not found — returns nil": {
+		"target ID not found — returns nil": {
 			packages: []ftypes.Package{
-				makePkg(parentUID, parentPURL, vulnUID),
+				makePkg(parentID, parentPURL, vulnID),
 			},
-			targetPURL: vulnUID,
-			expected:   nil,
+			targetID: vulnID,
+			expected: nil,
 		},
-		"package without PURL — falls back to UID as name": {
+		"package without PURL — falls back to Package.ID as name": {
 			packages: []ftypes.Package{
-				makePkg(vulnUID, vulnPURL),
-				makePkg("no-purl-root", nil, vulnUID),
+				makePkg(vulnID, vulnPURL),
+				makePkg("no-purl-root", nil, vulnID),
 			},
-			targetPURL: vulnUID,
-			expected:   [][]string{{"no-purl-root", "npm/vuln-pkg@1.0.0"}},
+			targetID: vulnID,
+			expected: [][]string{{"no-purl-root", "npm/vuln-pkg@1.0.0"}},
 		},
 		"max chains limit — stops at 10": {
 			packages: func() []ftypes.Package {
-				pkgs := []ftypes.Package{makePkg(vulnUID, vulnPURL)}
+				pkgs := []ftypes.Package{makePkg(vulnID, vulnPURL)}
 				for i := 0; i < 15; i++ {
-					uid := fmt.Sprintf("root-%d", i)
-					pkgs = append(pkgs, makePkg(uid, nil, vulnUID))
+					pkgs = append(pkgs, makePkg(fmt.Sprintf("root-%d", i), nil, vulnID))
 				}
 				return pkgs
 			}(),
-			targetPURL: vulnUID,
+			targetID: vulnID,
 			expected: func() [][]string {
 				var chains [][]string
 				for i := 0; i < maxDependencyChains; i++ {
@@ -1016,7 +1036,7 @@ func TestBuildDependencyChains(t *testing.T) {
 
 	for testName, testData := range testSet {
 		t.Run(testName, func(t *testing.T) {
-			result := buildDependencyChains(testData.targetPURL, testData.packages)
+			result := chainsFor(testData.targetID, testData.packages)
 			assert.Equal(t, testData.expected, result)
 		})
 	}
@@ -1026,18 +1046,18 @@ func TestBuildDependencyChains_CycleTerminates(t *testing.T) {
 	vulnPURL := newPURL("npm", "", "vuln-pkg", "1.0.0")
 	sibling1PURL := newPURL("npm", "", "sibling-1", "1.0.0")
 	sibling2PURL := newPURL("npm", "", "sibling-2", "1.0.0")
-	vulnUID := vulnPURL.String()
-	sibling1UID := sibling1PURL.String()
-	sibling2UID := sibling2PURL.String()
+	vulnID := "vuln-pkg@1.0.0"
+	sibling1ID := "sibling-1@1.0.0"
+	sibling2ID := "sibling-2@1.0.0"
 
 	// sibling1 and sibling2 mutually depend on each other, both depend on vuln
 	packages := []ftypes.Package{
-		makePkg(vulnUID, vulnPURL),
-		makePkg(sibling1UID, sibling1PURL, vulnUID, sibling2UID),
-		makePkg(sibling2UID, sibling2PURL, vulnUID, sibling1UID),
+		makePkg(vulnID, vulnPURL),
+		makePkg(sibling1ID, sibling1PURL, vulnID, sibling2ID),
+		makePkg(sibling2ID, sibling2PURL, vulnID, sibling1ID),
 	}
 
-	result := buildDependencyChains(vulnUID, packages)
+	result := chainsFor(vulnID, packages)
 
 	// Cycle guard must prevent infinite loop; exactly 2 finite chains produced
 	assert.Len(t, result, 2)
@@ -1052,22 +1072,41 @@ func TestBuildDependencyChains_CycleTerminates(t *testing.T) {
 func TestBuildDependencyChains_ChainLengthTrimmed(t *testing.T) {
 	// Build a linear chain 25 nodes deep: root -> n1 -> n2 -> ... -> vuln
 	vulnPURL := newPURL("npm", "", "vuln-pkg", "1.0.0")
-	vulnUID := vulnPURL.String()
+	vulnID := "vuln-pkg@1.0.0"
 
-	packages := []ftypes.Package{makePkg(vulnUID, vulnPURL)}
-	prevUID := vulnUID
+	packages := []ftypes.Package{makePkg(vulnID, vulnPURL)}
+	prevID := vulnID
 	for i := 0; i < 25; i++ {
-		uid := fmt.Sprintf("ancestor-%d", i)
-		packages = append(packages, makePkg(uid, nil, prevUID))
-		prevUID = uid
+		id := fmt.Sprintf("ancestor-%d", i)
+		packages = append(packages, makePkg(id, nil, prevID))
+		prevID = id
 	}
 
-	result := buildDependencyChains(vulnUID, packages)
+	result := chainsFor(vulnID, packages)
 	if assert.Len(t, result, 1) {
 		chain := result[0]
 		assert.Len(t, chain, maxDependencyChainLen, "chain should be trimmed to maxDependencyChainLen")
 		assert.Equal(t, "npm/vuln-pkg@1.0.0", chain[len(chain)-1], "vulnerable package must be last")
 	}
+}
+
+// TestBuildDependencyChains_GraphKeyedByPackageID is the regression test for the key-space
+// bug: Trivy's DependsOn references Package.ID, NOT Identifier.UID. With UID set to a value
+// distinct from ID, a UID-keyed implementation finds no parents and collapses this to a
+// single-element chain. The correct ID-keyed implementation yields the full transitive chain.
+func TestBuildDependencyChains_GraphKeyedByPackageID(t *testing.T) {
+	vulnPURL := newPURL("npm", "", "vuln-pkg", "1.0.0")
+	rootPURL := newPURL("npm", "", "root-app", "1.0.0")
+	vulnID := "vuln-pkg@1.0.0"
+	rootID := "root-app@1.0.0"
+
+	packages := []ftypes.Package{
+		makePkg(vulnID, vulnPURL),
+		makePkg(rootID, rootPURL, vulnID),
+	}
+
+	result := chainsFor(vulnID, packages)
+	assert.Equal(t, [][]string{{"npm/root-app@1.0.0", "npm/vuln-pkg@1.0.0"}}, result)
 }
 
 func TestTrimChainTail(t *testing.T) {

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -909,6 +909,200 @@ func TestPurlPrettyPrint(t *testing.T) {
 	assert.Equal(t, "type/namespace/name@1.2.0+incompatible", ppp)
 }
 
+func makePkg(uid string, purl *packageurl.PackageURL, dependsOn ...string) ftypes.Package {
+	return ftypes.Package{
+		Identifier: ftypes.PkgIdentifier{
+			UID:  uid,
+			PURL: purl,
+		},
+		DependsOn: dependsOn,
+	}
+}
+
+func newPURL(pkgType, namespace, name, version string) *packageurl.PackageURL {
+	return packageurl.NewPackageURL(pkgType, namespace, name, version, nil, "")
+}
+
+func TestBuildDependencyChains(t *testing.T) {
+	type testData struct {
+		packages    []ftypes.Package
+		targetPURL  string
+		expected    [][]string
+	}
+
+	vulnPURL := newPURL("npm", "", "vuln-pkg", "1.0.0")
+	parentPURL := newPURL("npm", "", "parent-pkg", "2.0.0")
+	grandparentPURL := newPURL("npm", "", "grandparent-pkg", "3.0.0")
+	sibling1PURL := newPURL("npm", "", "sibling-1", "1.0.0")
+	sibling2PURL := newPURL("npm", "", "sibling-2", "1.0.0")
+
+	vulnUID := vulnPURL.String()
+	parentUID := parentPURL.String()
+	grandparentUID := grandparentPURL.String()
+	sibling1UID := sibling1PURL.String()
+	sibling2UID := sibling2PURL.String()
+
+	testSet := map[string]testData{
+		"direct dependency — no parents, single-element chain": {
+			packages: []ftypes.Package{
+				makePkg(vulnUID, vulnPURL),
+			},
+			targetPURL: vulnUID,
+			expected:   [][]string{{"npm/vuln-pkg@1.0.0"}},
+		},
+		"single transitive chain — one parent": {
+			packages: []ftypes.Package{
+				makePkg(vulnUID, vulnPURL),
+				makePkg(parentUID, parentPURL, vulnUID),
+			},
+			targetPURL: vulnUID,
+			expected:   [][]string{{"npm/parent-pkg@2.0.0", "npm/vuln-pkg@1.0.0"}},
+		},
+		"deep transitive chain — two ancestors": {
+			packages: []ftypes.Package{
+				makePkg(vulnUID, vulnPURL),
+				makePkg(parentUID, parentPURL, vulnUID),
+				makePkg(grandparentUID, grandparentPURL, parentUID),
+			},
+			targetPURL: vulnUID,
+			expected:   [][]string{{"npm/grandparent-pkg@3.0.0", "npm/parent-pkg@2.0.0", "npm/vuln-pkg@1.0.0"}},
+		},
+		"multiple paths to root — two chains": {
+			packages: []ftypes.Package{
+				makePkg(vulnUID, vulnPURL),
+				makePkg(sibling1UID, sibling1PURL, vulnUID),
+				makePkg(sibling2UID, sibling2PURL, vulnUID),
+			},
+			targetPURL: vulnUID,
+			expected: [][]string{
+				{"npm/sibling-1@1.0.0", "npm/vuln-pkg@1.0.0"},
+				{"npm/sibling-2@1.0.0", "npm/vuln-pkg@1.0.0"},
+			},
+		},
+		"target PURL not found — returns nil": {
+			packages: []ftypes.Package{
+				makePkg(parentUID, parentPURL, vulnUID),
+			},
+			targetPURL: vulnUID,
+			expected:   nil,
+		},
+		"package without PURL — falls back to UID as name": {
+			packages: []ftypes.Package{
+				makePkg(vulnUID, vulnPURL),
+				makePkg("no-purl-root", nil, vulnUID),
+			},
+			targetPURL: vulnUID,
+			expected:   [][]string{{"no-purl-root", "npm/vuln-pkg@1.0.0"}},
+		},
+		"max chains limit — stops at 10": {
+			packages: func() []ftypes.Package {
+				pkgs := []ftypes.Package{makePkg(vulnUID, vulnPURL)}
+				for i := 0; i < 15; i++ {
+					uid := fmt.Sprintf("root-%d", i)
+					pkgs = append(pkgs, makePkg(uid, nil, vulnUID))
+				}
+				return pkgs
+			}(),
+			targetPURL: vulnUID,
+			expected: func() [][]string {
+				var chains [][]string
+				for i := 0; i < maxDependencyChains; i++ {
+					chains = append(chains, []string{fmt.Sprintf("root-%d", i), "npm/vuln-pkg@1.0.0"})
+				}
+				return chains
+			}(),
+		},
+	}
+
+	for testName, testData := range testSet {
+		t.Run(testName, func(t *testing.T) {
+			result := buildDependencyChains(testData.targetPURL, testData.packages)
+			assert.Equal(t, testData.expected, result)
+		})
+	}
+}
+
+func TestBuildDependencyChains_CycleTerminates(t *testing.T) {
+	vulnPURL := newPURL("npm", "", "vuln-pkg", "1.0.0")
+	sibling1PURL := newPURL("npm", "", "sibling-1", "1.0.0")
+	sibling2PURL := newPURL("npm", "", "sibling-2", "1.0.0")
+	vulnUID := vulnPURL.String()
+	sibling1UID := sibling1PURL.String()
+	sibling2UID := sibling2PURL.String()
+
+	// sibling1 and sibling2 mutually depend on each other, both depend on vuln
+	packages := []ftypes.Package{
+		makePkg(vulnUID, vulnPURL),
+		makePkg(sibling1UID, sibling1PURL, vulnUID, sibling2UID),
+		makePkg(sibling2UID, sibling2PURL, vulnUID, sibling1UID),
+	}
+
+	result := buildDependencyChains(vulnUID, packages)
+
+	// Cycle guard must prevent infinite loop; exactly 2 finite chains produced
+	assert.Len(t, result, 2)
+	for _, chain := range result {
+		// Each chain must end with the vulnerable package
+		assert.Equal(t, "npm/vuln-pkg@1.0.0", chain[len(chain)-1])
+		// Chain is finite (cycle broken, so length <= 3 for this graph)
+		assert.LessOrEqual(t, len(chain), 3)
+	}
+}
+
+func TestBuildDependencyChains_ChainLengthTrimmed(t *testing.T) {
+	// Build a linear chain 25 nodes deep: root -> n1 -> n2 -> ... -> vuln
+	vulnPURL := newPURL("npm", "", "vuln-pkg", "1.0.0")
+	vulnUID := vulnPURL.String()
+
+	packages := []ftypes.Package{makePkg(vulnUID, vulnPURL)}
+	prevUID := vulnUID
+	for i := 0; i < 25; i++ {
+		uid := fmt.Sprintf("ancestor-%d", i)
+		packages = append(packages, makePkg(uid, nil, prevUID))
+		prevUID = uid
+	}
+
+	result := buildDependencyChains(vulnUID, packages)
+	if assert.Len(t, result, 1) {
+		chain := result[0]
+		assert.Len(t, chain, maxDependencyChainLen, "chain should be trimmed to maxDependencyChainLen")
+		assert.Equal(t, "npm/vuln-pkg@1.0.0", chain[len(chain)-1], "vulnerable package must be last")
+	}
+}
+
+func TestTrimChainTail(t *testing.T) {
+	type testData struct {
+		chain    []string
+		max      int
+		expected []string
+	}
+
+	testSet := map[string]testData{
+		"chain shorter than max — returned unchanged": {
+			chain:    []string{"a", "b", "c"},
+			max:      5,
+			expected: []string{"a", "b", "c"},
+		},
+		"chain equal to max — returned unchanged": {
+			chain:    []string{"a", "b", "c"},
+			max:      3,
+			expected: []string{"a", "b", "c"},
+		},
+		"chain longer than max — tail kept": {
+			chain:    []string{"a", "b", "c", "d", "e"},
+			max:      3,
+			expected: []string{"c", "d", "e"},
+		},
+	}
+
+	for testName, testData := range testSet {
+		t.Run(testName, func(t *testing.T) {
+			result := trimChainTail(testData.chain, testData.max)
+			assert.Equal(t, testData.expected, result)
+		})
+	}
+}
+
 type mockRunnerFactory struct {
 	mockRunner artifact.Runner
 }

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -278,20 +278,23 @@ func TestRun(t *testing.T) {
 
 	// Assert
 	if assert.NoError(t, err) {
+		pkg1Chain := `[["type/@namespace/package-1@version+incompatible"]]`
 		expectedIssues := []codacy.Issue{
 			{
-				File:      fileName,
-				Line:      1,
-				PatternID: ruleIDVulnerabilityCritical,
-				Message:   "Insecure dependency type/@namespace/package-1@version+incompatible (vuln id: vuln title) (update to vuln fixed)",
-				SourceID:  "vuln id",
+				File:        fileName,
+				Line:        1,
+				PatternID:   ruleIDVulnerabilityCritical,
+				Message:     "Insecure dependency type/@namespace/package-1@version+incompatible (vuln id: vuln title) (update to vuln fixed)",
+				SourceID:    "vuln id",
+				ExtraFields: json.RawMessage(`{"CVE":"vuln id","dependenciesChains":` + pkg1Chain + `,"fixVersion":"vuln fixed"}`),
 			},
 			{
-				File:      fileName,
-				Line:      1,
-				PatternID: ruleIDVulnerabilityHigh,
-				Message:   "Insecure dependency type/@namespace/package-1@version+incompatible (vuln id no fixed version: vuln no fixed version) (no fix available)",
-				SourceID:  "vuln id no fixed version",
+				File:        fileName,
+				Line:        1,
+				PatternID:   ruleIDVulnerabilityHigh,
+				Message:     "Insecure dependency type/@namespace/package-1@version+incompatible (vuln id no fixed version: vuln no fixed version) (no fix available)",
+				SourceID:    "vuln id no fixed version",
+				ExtraFields: json.RawMessage(`{"CVE":"vuln id no fixed version","dependenciesChains":` + pkg1Chain + `,"fixVersion":""}`),
 			},
 			{
 				File:      fileName,


### PR DESCRIPTION
## Summary

- Bumps `codacy-engine-golang-seed` to `v8.0.4` (which adds `ExtraFields json.RawMessage` to `Issue`)
- For each vulnerability issue, populates `ExtraFields` with a JSON object containing:
  - `dependenciesChains`: up to 10 DFS chains from root to vulnerable package (root-first ordering); each chain capped at 20 nodes (tail kept, vulnerable package last); single-element chain = direct dependency
  - `CVE`: vulnerability ID (same as `SourceID`)
  - `fixVersion`: least disruptive fix version, or `""` if none available
- Adds `buildDependencyChains` + `trimChainTail` helpers
- Cycle guard: per-DFS-path visited set prevents infinite loops on malformed dep graphs

## Example output

```json
{
  "extraFields": {
    "dependenciesChains": [
      ["root-app", "@codacy/codacy-mcp", "@modelcontextprotocol/sdk"],
      ["root-app", "express-rate-limit", "express", "path-to-regexp"]
    ],
    "CVE": "CVE-2024-12345",
    "fixVersion": "1.2.4"
  }
}
```

## Part of

Dependency chain propagation initiative — **TASK 2** of the SRM dependency chains plan.

## Test plan

Tested locally ✅ 

```
DEMO=/Users/czak/.claude/jobs/e7428284/tmp/demo
docker run --rm \
  -v "$DEMO":/src \
  -v "$DEMO/.codacyrc":/.codacyrc \
  -v "$HOME/Library/Caches/trivy/db":/dist/cache/codacy-trivy/db:ro \
  codacy-trivy:pr296 \
  | jq -c 'select(.extraFields) | {cve:.extraFields.CVE, chains:.extraFields.dependenciesChains}'
{"cve":"CVE-2021-3749","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2025-27152","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-25639","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42033","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42035","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42043","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2020-28168","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2023-45857","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2025-62718","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-40175","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42034","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42036","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42038","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42039","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42041","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42042","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2026-42040","chains":[["npm/axios@0.21.0"]]}
{"cve":"CVE-2022-0536","chains":[["npm/axios@0.21.0","npm/follow-redirects@1.14.7"]]}
{"cve":"CVE-2023-26159","chains":[["npm/axios@0.21.0","npm/follow-redirects@1.14.7"]]}
{"cve":"CVE-2024-28849","chains":[["npm/axios@0.21.0","npm/follow-redirects@1.14.7"]]}
{"cve":"GHSA-r4q5-vmmm-2653","chains":[["npm/axios@0.21.0","npm/follow-redirects@1.14.7"]]}
    ~/GI/codacy/codacy-trivy/.cl/worktrees/pr296-fix    worktree-pr296-fix ? 
 ``` 


- [x] All `internal/tool` tests pass (updated `TestRun` to include expected `ExtraFields`)
- [x] Direct dependency → single-element chain
- [x] Mock runner tests (`TestRunInvalidExecutionConfiguration`, `TestRunNewRunnerError`, etc.) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)