### PR TITLE
chore: regenerate fixture results for Trivy DB update

### DIFF
--- a/docs/multiple-tests/all-patterns/results.xml
+++ b/docs/multiple-tests/all-patterns/results.xml
@@ -24,7 +24,7 @@
         <error
             source="vulnerability_medium"
             line="1"
-            message="Insecure dependency maven/org.apache.logging.log4j/log4j-core@2.17.0 (CVE-2025-68161: The Socket Appender in Apache Log4j Core versions 2.0-beta9 through 2. ...) (update to 2.25.3)"
+            message="Insecure dependency maven/org.apache.logging.log4j/log4j-core@2.17.0 (CVE-2025-68161: Apache Log4j: Apache Log4j Core: Information disclosure via missing TLS hostname verification) (update to 2.25.3)"
             severity="warning"
         />
         <error
@@ -54,7 +54,7 @@
         <error
             source="vulnerability_medium"
             line="4"
-            message="Insecure dependency maven/org.apache.cxf/cxf-rt-transports-http@4.0.0 (CVE-2024-41172: Apache CXF allows unrestricted memory consumption in CXF HTTP clients) (update to 4.0.5)"
+            message="Insecure dependency maven/org.apache.cxf/cxf-rt-transports-http@4.0.0 (CVE-2024-41172: apache: cxf: org.apache.cxf:cxf-rt-transports-http: unrestricted memory consumption in CXF HTTP clients) (update to 4.0.5)"
             severity="warning"
         />
     </file>

--- a/docs/multiple-tests/pattern-vulnerability-critical/results.xml
+++ b/docs/multiple-tests/pattern-vulnerability-critical/results.xml
@@ -4,7 +4,7 @@
         <error
             source="vulnerability_critical"
             line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24790: The various Is methods (IsPrivate, IsLoopback, etc) did not work as ex ...) (update to 1.21.11)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24790: golang: net/netip: Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses) (update to 1.21.11)"
             severity="error"
         />
         <error
@@ -40,7 +40,7 @@
         <error
             source="vulnerability_critical"
             line="19"
-            message="Insecure dependency pypi/pymysql@1.1.0 (CVE-2024-36039: PyMySQL through 1.1.0 allows SQL injection if used with untrusted JSON ...) (update to 1.1.1)"
+            message="Insecure dependency pypi/pymysql@1.1.0 (CVE-2024-36039: python-pymysql: SQL injection if used with untrusted JSON input) (update to 1.1.1)"
             severity="error"
         />
     </file>

--- a/docs/multiple-tests/pattern-vulnerability-high/results.xml
+++ b/docs/multiple-tests/pattern-vulnerability-high/results.xml
@@ -12,79 +12,13 @@
         <error
             source="vulnerability_high"
             line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-22871: The net/http package improperly accepts a bare LF as a line terminator ...) (update to 1.23.8)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2023-45288: golang: net/http, x/net/http2: unlimited number of CONTINUATION frames causes DoS) (update to 1.21.9)"
             severity="high"
         />
         <error
             source="vulnerability_high"
             line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-47906: If the PATH environment variable contains paths which are executables  ...) (update to 1.23.12)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-47907: Cancelling a query (e.g. by cancelling the context passed to one of th ...) (update to 1.23.12)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-47912: The Parse function permits values other than IPv6 addresses to be incl ...) (update to 1.24.8)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58183: tar.Reader does not set a maximum size on the number of sparse region  ...) (update to 1.24.8)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58185: Parsing a maliciously crafted DER payload could allocate large amounts ...) (update to 1.24.8)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58186: Despite HTTP headers having a default limit of 1MB, the number of cook ...) (update to 1.24.8)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58187: Due to the design of the name constraint checking algorithm, the proce ...) (update to 1.24.9)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58188: Validating certificate chains which contain DSA public keys can cause  ...) (update to 1.24.8)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58189: When Conn.Handshake fails during ALPN negotiation the error contains a ...) (update to 1.24.8)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61723: The processing time for parsing some invalid inputs scales non-linearl ...) (update to 1.24.8)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61724: The Reader.ReadResponse function constructs a response string through  ...) (update to 1.24.8)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61725: The ParseAddress function constructs domain-literal address components ...) (update to 1.24.8)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-34156: encoding/gob: golang: Calling Decoder.Decode on a message which contains deeply nested structures can cause a panic due to stack exhaustion) (update to 1.22.7)"
             severity="high"
         />
         <error
@@ -96,13 +30,7 @@
         <error
             source="vulnerability_high"
             line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61727: An excluded subdomain constraint in a certificate chain does not restr ...) (update to 1.24.11)"
-            severity="high"
-        />
-        <error
-            source="vulnerability_high"
-            line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61729: Within HostnameError.Error(), when constructing an error string, there ...) (update to 1.24.11)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61729: crypto/x509: golang: Denial of Service due to excessive resource consumption via crafted certificate) (update to 1.24.11)"
             severity="high"
         />
         <error
@@ -132,7 +60,7 @@
         <error
             source="vulnerability_high"
             line="5"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2026-33811: When using LookupCNAME with the cgo DNS resolver, a very long CNAME re ...) (update to 1.25.10)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2026-33811: net: golang: Go net package: Denial of Service via long CNAME response in LookupCNAME) (update to 1.25.10)"
             severity="high"
         />
         <error
@@ -186,13 +114,13 @@
         <error
             source="vulnerability_high"
             line="8"
-            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2024-12055: Ollama Allows Out-of-Bounds Read) (no fix available)"
+            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2024-12055: ollama: DoS using malicious gguf model file in ollama/ollama) (no fix available)"
             severity="high"
         />
         <error
             source="vulnerability_high"
             line="8"
-            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2024-12886: Ollama Vulnerable to Denial of Service (DoS) via Crafted GZIP) (no fix available)"
+            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2024-12886: ollama: Out-Of-Memory (OOM) Vulnerability in ollama/ollama) (no fix available)"
             severity="high"
         />
         <error
@@ -204,31 +132,31 @@
         <error
             source="vulnerability_high"
             line="8"
-            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2024-8063: Ollama Divide by Zero Vulnerability) (no fix available)"
+            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2024-8063: ollama: Divide by Zero in ollama/ollama) (no fix available)"
             severity="high"
         />
         <error
             source="vulnerability_high"
             line="8"
-            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-0312: Ollama Denial of Service (DoS) via Null Pointer Dereference) (no fix available)"
+            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-0312: ollama: NULL Pointer Dereference in ollama/ollama) (no fix available)"
             severity="high"
         />
         <error
             source="vulnerability_high"
             line="8"
-            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-0315: Ollama Allocation of Resources Without Limits or Throttling vulnerability) (no fix available)"
+            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-0315: ollama: Allocation of Resources Without Limits or Throttling in ollama/ollama) (no fix available)"
             severity="high"
         />
         <error
             source="vulnerability_high"
             line="8"
-            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-0317: Ollama Divide By Zero vulnerability) (no fix available)"
+            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-0317: ollama: Divide By Zero in ollama/ollama) (no fix available)"
             severity="high"
         />
         <error
             source="vulnerability_high"
             line="8"
-            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-1975: Ollama Server Vulnerable to Denial of Service (DoS) Attack) (no fix available)"
+            message="Insecure dependency golang/github.com/ollama/ollama@v0.1.46 (CVE-2025-1975: ollama: Improper Validation of Array Index in ollama/ollama) (no fix available)"
             severity="high"
         />
         <error
@@ -248,7 +176,7 @@
         <error
             source="vulnerability_high"
             line="14"
-            message="Insecure dependency npm/axios@0.21.0 (CVE-2025-27152: axios is a promise based HTTP client for the browser and node.js. The  ...) (update to 0.30.0)"
+            message="Insecure dependency npm/axios@0.21.0 (CVE-2025-27152: axios: Possible SSRF and Credential Leakage via Absolute URL in axios Requests) (update to 0.30.0)"
             severity="high"
         />
         <error
@@ -273,6 +201,18 @@
             source="vulnerability_high"
             line="14"
             message="Insecure dependency npm/axios@0.21.0 (CVE-2026-42043: axios: Axios: NO_PROXY bypass via crafted URL) (update to 0.31.1)"
+            severity="high"
+        />
+        <error
+            source="vulnerability_high"
+            line="14"
+            message="Insecure dependency npm/axios@0.21.0 (CVE-2026-44492: axios's shouldBypassProxy does not recognize IPv4-mapped IPv6 addresses, allowing NO_PROXY bypass (incomplete fix for CVE-2025-62718)) (update to 0.32.0)"
+            severity="high"
+        />
+        <error
+            source="vulnerability_high"
+            line="14"
+            message="Insecure dependency npm/axios@0.21.0 (CVE-2026-44495: axios Vulnerable to Credential Theft and Response Hijacking via Prototype Pollution Gadget in Config Merge) (update to 0.31.1)"
             severity="high"
         />
     </file>
@@ -286,7 +226,7 @@
         <error
             source="vulnerability_high"
             line="5"
-            message="Insecure dependency npm/axios@0.21.0 (CVE-2025-27152: axios is a promise based HTTP client for the browser and node.js. The  ...) (update to 0.30.0)"
+            message="Insecure dependency npm/axios@0.21.0 (CVE-2025-27152: axios: Possible SSRF and Credential Leakage via Absolute URL in axios Requests) (update to 0.30.0)"
             severity="high"
         />
         <error
@@ -311,6 +251,18 @@
             source="vulnerability_high"
             line="5"
             message="Insecure dependency npm/axios@0.21.0 (CVE-2026-42043: axios: Axios: NO_PROXY bypass via crafted URL) (update to 0.31.1)"
+            severity="high"
+        />
+        <error
+            source="vulnerability_high"
+            line="5"
+            message="Insecure dependency npm/axios@0.21.0 (CVE-2026-44492: axios's shouldBypassProxy does not recognize IPv4-mapped IPv6 addresses, allowing NO_PROXY bypass (incomplete fix for CVE-2025-62718)) (update to 0.32.0)"
+            severity="high"
+        />
+        <error
+            source="vulnerability_high"
+            line="5"
+            message="Insecure dependency npm/axios@0.21.0 (CVE-2026-44495: axios Vulnerable to Credential Theft and Response Hijacking via Prototype Pollution Gadget in Config Merge) (update to 0.31.1)"
             severity="high"
         />
     </file>

--- a/docs/multiple-tests/pattern-vulnerability-medium/results.xml
+++ b/docs/multiple-tests/pattern-vulnerability-medium/results.xml
@@ -10,79 +10,61 @@
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2023-45288: An attacker may cause an HTTP/2 endpoint to read arbitrary amounts of  ...) (update to 1.21.9)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2023-45289: golang: net/http/cookiejar: incorrect forwarding of sensitive headers and cookies on HTTP redirect) (update to 1.21.8)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2023-45289: When following an HTTP redirect to a domain which is not a subdomain m ...) (update to 1.21.8)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2023-45290: golang: net/http: golang: mime/multipart: golang: net/textproto: memory exhaustion in Request.ParseMultipartForm) (update to 1.21.8)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2023-45290: When parsing a multipart form (either explicitly with Request.ParseMul ...) (update to 1.21.8)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24783: golang: crypto/x509: Verify panics on certificates with an unknown public key algorithm) (update to 1.21.8)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24783: Verifying a certificate chain which contains a certificate with an unk ...) (update to 1.21.8)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24784: golang: net/mail: comments in display names are incorrectly handled) (update to 1.21.8)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24784: The ParseAddressList function incorrectly handles comments (text withi ...) (update to 1.21.8)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24785: golang: html/template: errors returned from MarshalJSON methods may break template escaping) (update to 1.21.8)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24785: If errors returned from MarshalJSON methods contain user controlled da ...) (update to 1.21.8)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24789: golang: archive/zip: Incorrect handling of certain ZIP files) (update to 1.21.11)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24789: The archive/zip package's handling of certain types of invalid zip fil ...) (update to 1.21.11)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24791: net/http: Denial of service due to improper 100-continue handling in net/http) (update to 1.21.12)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-24791: The net/http HTTP/1.1 client mishandled the case where a server respon ...) (update to 1.21.12)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-34155: go/parser: golang: Calling any of the Parse functions containing deeply nested literals can cause a panic/stack exhaustion) (update to 1.22.7)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-34155: Calling any of the Parse functions on Go source code which contains de ...) (update to 1.22.7)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-34158: go/build/constraint: golang: Calling Parse on a &quot;// +build&quot; build tag line with deeply nested expressions can cause a panic due to stack exhaustion) (update to 1.22.7)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-34156: Calling Decoder.Decode on a message which contains deeply nested struc ...) (update to 1.22.7)"
-            severity="warning"
-        />
-        <error
-            source="vulnerability_medium"
-            line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-34158: Calling Parse on a &quot;// +build&quot; build tag line with deeply nested expre ...) (update to 1.22.7)"
-            severity="warning"
-        />
-        <error
-            source="vulnerability_medium"
-            line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-45336: The HTTP client drops sensitive headers after following a cross-domain ...) (update to 1.22.11)"
-            severity="warning"
-        />
-        <error
-            source="vulnerability_medium"
-            line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-45341: A certificate with a URI which has a IPv6 address with a zone ID may i ...) (update to 1.22.11)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-45336: golang: net/http: net/http: sensitive headers incorrectly sent after cross-domain redirect) (update to 1.22.11)"
             severity="warning"
         />
         <error
@@ -94,13 +76,19 @@
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-22866: Due to the usage of a variable time instruction in the assembly implem ...) (update to 1.22.12)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-22866: crypto/internal/nistec: golang: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec) (update to 1.22.12)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-22870: Matching of hosts against proxy patterns can improperly treat an IPv6  ...) (update to 1.23.7)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-22870: golang.org/x/net/proxy: golang.org/x/net/http/httpproxy: HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net) (update to 1.23.7)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-22871: net/http: Request smuggling due to acceptance of invalid chunked data in net/http) (update to 1.23.8)"
             severity="warning"
         />
         <error
@@ -112,7 +100,79 @@
         <error
             source="vulnerability_medium"
             line="3"
-            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-4673: Proxy-Authorization and Proxy-Authenticate headers persisted on cross- ...) (update to 1.23.10)"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-4673: net/http: Sensitive headers not cleared on cross-origin redirect in net/http) (update to 1.23.10)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-47906: os/exec: Unexpected paths returned from LookPath in os/exec) (update to 1.23.12)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-47907: database/sql: Postgres Scan Race Condition) (update to 1.23.12)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-47912: net/url: Insufficient validation of bracketed IPv6 hostnames in net/url) (update to 1.24.8)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58183: golang: archive/tar: Unbounded allocation when parsing GNU sparse map) (update to 1.24.8)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58185: encoding/asn1: Parsing DER payload can cause memory exhaustion in encoding/asn1) (update to 1.24.8)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58187: crypto/x509: Quadratic complexity when checking name constraints in crypto/x509) (update to 1.24.9)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58188: crypto/x509: golang: Panic when validating certificates with DSA public keys in crypto/x509) (update to 1.24.8)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58189: crypto/tls: go crypto/tls ALPN negotiation error contains attacker controlled information) (update to 1.24.8)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61723: encoding/pem: Quadratic complexity when parsing some invalid inputs in encoding/pem) (update to 1.24.8)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61724: net/textproto: Excessive CPU consumption in Reader.ReadResponse in net/textproto) (update to 1.24.8)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61725: net/mail: Excessive CPU consumption in ParseAddress in net/mail) (update to 1.24.8)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
+            line="3"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-61727: golang: crypto/x509: excluded subdomain constraint does not restrict wildcard SANs) (update to 1.24.11)"
             severity="warning"
         />
         <error
@@ -160,19 +220,19 @@
         <error
             source="vulnerability_medium"
             line="7"
-            message="Insecure dependency golang/golang.org/x/net@v0.16.0 (CVE-2023-45288: An attacker may cause an HTTP/2 endpoint to read arbitrary amounts of  ...) (update to 0.23.0)"
+            message="Insecure dependency golang/golang.org/x/net@v0.16.0 (CVE-2023-45288: golang: net/http, x/net/http2: unlimited number of CONTINUATION frames causes DoS) (update to 0.23.0)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="7"
-            message="Insecure dependency golang/golang.org/x/net@v0.16.0 (CVE-2025-22870: Matching of hosts against proxy patterns can improperly treat an IPv6  ...) (update to 0.36.0)"
+            message="Insecure dependency golang/golang.org/x/net@v0.16.0 (CVE-2025-22870: golang.org/x/net/proxy: golang.org/x/net/http/httpproxy: HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net) (update to 0.36.0)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="7"
-            message="Insecure dependency golang/golang.org/x/net@v0.16.0 (CVE-2025-22872: The tokenizer incorrectly interprets tags with unquoted attribute valu ...) (update to 0.38.0)"
+            message="Insecure dependency golang/golang.org/x/net@v0.16.0 (CVE-2025-22872: golang.org/x/net/html: Incorrect Neutralization of Input During Web Page Generation in x/net in golang.org/x/net) (update to 0.38.0)"
             severity="warning"
         />
     </file>
@@ -186,7 +246,7 @@
         <error
             source="vulnerability_medium"
             line="1"
-            message="Insecure dependency maven/org.apache.logging.log4j/log4j-core@2.17.0 (CVE-2025-68161: The Socket Appender in Apache Log4j Core versions 2.0-beta9 through 2. ...) (update to 2.25.3)"
+            message="Insecure dependency maven/org.apache.logging.log4j/log4j-core@2.17.0 (CVE-2025-68161: Apache Log4j: Apache Log4j Core: Information disclosure via missing TLS hostname verification) (update to 2.25.3)"
             severity="warning"
         />
         <error
@@ -212,7 +272,7 @@
         <error
             source="vulnerability_medium"
             line="14"
-            message="Insecure dependency maven/org.apache.logging.log4j/log4j-core@2.17.0 (CVE-2025-68161: The Socket Appender in Apache Log4j Core versions 2.0-beta9 through 2. ...) (update to 2.25.3)"
+            message="Insecure dependency maven/org.apache.logging.log4j/log4j-core@2.17.0 (CVE-2025-68161: Apache Log4j: Apache Log4j Core: Information disclosure via missing TLS hostname verification) (update to 2.25.3)"
             severity="warning"
         />
         <error
@@ -291,6 +351,12 @@
         />
         <error
             source="vulnerability_medium"
+            line="14"
+            message="Insecure dependency npm/axios@0.21.0 (CVE-2026-44490: axios has DoS &amp; Header Injection via Prototype Pollution Read-Side Gadgets in axios merge functions) (update to 0.32.0)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
             line="23"
             message="Insecure dependency npm/follow-redirects@1.15.6 (GHSA-r4q5-vmmm-2653: follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets) (update to 1.16.0)"
             severity="warning"
@@ -359,6 +425,12 @@
         />
         <error
             source="vulnerability_medium"
+            line="5"
+            message="Insecure dependency npm/axios@0.21.0 (CVE-2026-44490: axios has DoS &amp; Header Injection via Prototype Pollution Read-Side Gadgets in axios merge functions) (update to 0.32.0)"
+            severity="warning"
+        />
+        <error
+            source="vulnerability_medium"
             line="12"
             message="Insecure dependency npm/follow-redirects@1.15.6 (GHSA-r4q5-vmmm-2653: follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets) (update to 1.16.0)"
             severity="warning"
@@ -380,13 +452,13 @@
         <error
             source="vulnerability_medium"
             line="131"
-            message="Insecure dependency pypi/requests@2.30.0 (CVE-2024-35195: Requests is a HTTP library. Prior to 2.32.0, when making requests thro ...) (update to 2.32.0)"
+            message="Insecure dependency pypi/requests@2.30.0 (CVE-2024-35195: requests: subsequent requests to the same host ignore cert verification) (update to 2.32.0)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="131"
-            message="Insecure dependency pypi/requests@2.30.0 (CVE-2024-47081: Requests is a HTTP library. Due to a URL parsing issue, Requests relea ...) (update to 2.32.4)"
+            message="Insecure dependency pypi/requests@2.30.0 (CVE-2024-47081: requests: Requests vulnerable to .netrc credentials leak via malicious URLs) (update to 2.32.4)"
             severity="warning"
         />
         <error
@@ -398,13 +470,13 @@
         <error
             source="vulnerability_medium"
             line="140"
-            message="Insecure dependency pypi/urllib3@2.2.2 (CVE-2025-50181: urllib3 is a user-friendly HTTP client library for Python. Prior to 2. ...) (update to 2.5.0)"
+            message="Insecure dependency pypi/urllib3@2.2.2 (CVE-2025-50181: urllib3: urllib3 redirects are not disabled when retries are disabled on PoolManager instantiation) (update to 2.5.0)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="140"
-            message="Insecure dependency pypi/urllib3@2.2.2 (CVE-2025-50182: urllib3 is a user-friendly HTTP client library for Python. Starting in ...) (update to 2.5.0)"
+            message="Insecure dependency pypi/urllib3@2.2.2 (CVE-2025-50182: urllib3: urllib3 does not control redirects in browsers and Node.js) (update to 2.5.0)"
             severity="warning"
         />
     </file>
@@ -418,13 +490,13 @@
         <error
             source="vulnerability_medium"
             line="2"
-            message="Insecure dependency pypi/requests@v2.30.0 (CVE-2024-35195: Requests is a HTTP library. Prior to 2.32.0, when making requests thro ...) (update to 2.32.0)"
+            message="Insecure dependency pypi/requests@v2.30.0 (CVE-2024-35195: requests: subsequent requests to the same host ignore cert verification) (update to 2.32.0)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="2"
-            message="Insecure dependency pypi/requests@v2.30.0 (CVE-2024-47081: Requests is a HTTP library. Due to a URL parsing issue, Requests relea ...) (update to 2.32.4)"
+            message="Insecure dependency pypi/requests@v2.30.0 (CVE-2024-47081: requests: Requests vulnerable to .netrc credentials leak via malicious URLs) (update to 2.32.4)"
             severity="warning"
         />
         <error
@@ -444,13 +516,13 @@
         <error
             source="vulnerability_medium"
             line="4"
-            message="Insecure dependency gem/puma@6.3.0 (CVE-2024-21647: Puma is a web server for Ruby/Rack applications built for parallelism. ...) (update to ~&gt; 5.6.8, &gt;= 6.4.2)"
+            message="Insecure dependency gem/puma@6.3.0 (CVE-2024-21647: rubygem-puma: HTTP request smuggling when parsing chunked Transfer-Encoding Bodies) (update to ~&gt; 5.6.8, &gt;= 6.4.2)"
             severity="warning"
         />
         <error
             source="vulnerability_medium"
             line="4"
-            message="Insecure dependency gem/puma@6.3.0 (CVE-2024-45614: Puma is a Ruby/Rack web server built for parallelism. In affected vers ...) (update to ~&gt; 5.6.9, &gt;= 6.4.3)"
+            message="Insecure dependency gem/puma@6.3.0 (CVE-2024-45614: rubygem-puma: Header normalization allows for client to clobber proxy set headers) (update to ~&gt; 5.6.9, &gt;= 6.4.3)"
             severity="warning"
         />
     </file>

--- a/docs/multiple-tests/pattern-vulnerability-minor/results.xml
+++ b/docs/multiple-tests/pattern-vulnerability-minor/results.xml
@@ -4,6 +4,18 @@
         <error
             source="vulnerability_minor"
             line="5"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2024-45341: golang: crypto/x509: crypto/x509: usage of IPv6 zone IDs can bypass URI name constraints) (update to 1.22.11)"
+            severity="info"
+        />
+        <error
+            source="vulnerability_minor"
+            line="5"
+            message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2025-58186: golang.org/net/http: Lack of limit when parsing cookies can cause memory exhaustion in net/http) (update to 1.24.8)"
+            severity="info"
+        />
+        <error
+            source="vulnerability_minor"
+            line="5"
             message="Insecure dependency golang/stdlib@v1.21.4 (CVE-2026-27139: os: FileInfo can escape from a Root in golang os module) (update to 1.25.8)"
             severity="info"
         />
@@ -28,25 +40,25 @@
         <error
             source="vulnerability_minor"
             line="26"
-            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42459: In the Elliptic package 6.5.6 for Node.js, EDDSA signature malleabilit ...) (update to 6.5.7)"
+            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42459: elliptic: nodejs/elliptic: EDDSA signature malleability due to missing signature length check) (update to 6.5.7)"
             severity="info"
         />
         <error
             source="vulnerability_minor"
             line="26"
-            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42460: In the Elliptic package 6.5.6 for Node.js, ECDSA signature malleabilit ...) (update to 6.5.7)"
+            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42460: elliptic: nodejs/elliptic: ECDSA signature malleability due to missing checks) (update to 6.5.7)"
             severity="info"
         />
         <error
             source="vulnerability_minor"
             line="26"
-            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42461: In the Elliptic package 6.5.6 for Node.js, ECDSA signature malleabilit ...) (update to 6.5.7)"
+            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42461: elliptic: nodejs/elliptic: ECDSA implementation malleability due to BER-enconded signatures being allowed) (update to 6.5.7)"
             severity="info"
         />
         <error
             source="vulnerability_minor"
             line="26"
-            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-48948: The Elliptic package 6.5.7 for Node.js, in its for ECDSA implementatio ...) (update to 6.6.0)"
+            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-48948: elliptic: ECDSA signature verification error may reject legitimate transactions) (update to 6.6.0)"
             severity="info"
         />
         <error
@@ -60,25 +72,25 @@
         <error
             source="vulnerability_minor"
             line="15"
-            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42459: In the Elliptic package 6.5.6 for Node.js, EDDSA signature malleabilit ...) (update to 6.5.7)"
+            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42459: elliptic: nodejs/elliptic: EDDSA signature malleability due to missing signature length check) (update to 6.5.7)"
             severity="info"
         />
         <error
             source="vulnerability_minor"
             line="15"
-            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42460: In the Elliptic package 6.5.6 for Node.js, ECDSA signature malleabilit ...) (update to 6.5.7)"
+            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42460: elliptic: nodejs/elliptic: ECDSA signature malleability due to missing checks) (update to 6.5.7)"
             severity="info"
         />
         <error
             source="vulnerability_minor"
             line="15"
-            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42461: In the Elliptic package 6.5.6 for Node.js, ECDSA signature malleabilit ...) (update to 6.5.7)"
+            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-42461: elliptic: nodejs/elliptic: ECDSA implementation malleability due to BER-enconded signatures being allowed) (update to 6.5.7)"
             severity="info"
         />
         <error
             source="vulnerability_minor"
             line="15"
-            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-48948: The Elliptic package 6.5.7 for Node.js, in its for ECDSA implementatio ...) (update to 6.6.0)"
+            message="Insecure dependency npm/elliptic@6.5.6 (CVE-2024-48948: elliptic: ECDSA signature verification error may reject legitimate transactions) (update to 6.6.0)"
             severity="info"
         />
         <error


### PR DESCRIPTION
Trivy vulnerability DB updated since last fixture generation. Regenerated all results.xml files using the `scripts/regenerate_fixtures.py` script against the latest `codacy-trivy:latest` local Docker image (Trivy 0.70.0).

Changed fixture counts vs previous:
- all-patterns: minor updates
- pattern-vulnerability-critical: minor updates
- pattern-vulnerability-high: 57 → 49 issues
- pattern-vulnerability-medium: 75 → 89 issues
- pattern-vulnerability-minor: 19 → 21 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)