### PR TITLE
fix: ECR mirroring only overrides existing images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@13.0.2
+  codacy: codacy/base@13.0.4
   codacy_plugins_test: codacy/plugins-test@2.1.2
 
 references:
@@ -125,7 +125,7 @@ workflows:
           source_name: codacy/codacy-trivy
           mirror_name: codacy/codacy-trivy
           source_tag: $(cat .previous_version)
-          force: true
+          overwrite_only_existing: true
           requires:
             - publish_dockerhub
       - codacy/mirror_to_ecr:
@@ -135,7 +135,7 @@ workflows:
           source_name: codacy/codacy-trivy
           mirror_name: codacy/codacy-trivy
           source_tag: $(cat .previous_version)
-          force: true
+          overwrite_only_existing: true
           requires:
             - publish_dockerhub
       - codacy/mirror_to_ecr:
@@ -145,6 +145,6 @@ workflows:
           source_name: codacy/codacy-trivy
           mirror_name: codacy/codacy-trivy
           source_tag: $(cat .previous_version)
-          force: true
+          overwrite_only_existing: true
           requires:
             - publish_dockerhub


### PR DESCRIPTION
This makes it impossible to delete an image currently in production but the trade-off is that we get an updated DB only if we are using the latest version of Trivy. The experience is not very different from today where we update the latest image and if we are not using it in codacy-tools the update is not actually used by our users, so basically we are not losing anything